### PR TITLE
feat: set alias path for imports

### DIFF
--- a/src/templates/predefined/actions/AppResult.ejs.t
+++ b/src/templates/predefined/actions/AppResult.ejs.t
@@ -1,7 +1,7 @@
 ---
 to: App/Application/Utils/AppResult.ts
 ---
-import HttpStatusCode from "./HttpStatusCode";
+import HttpStatusCode from "@application/Utils/HttpStatusCode";
 
 class AppResult {
   readonly status: HttpStatusCode;

--- a/src/templates/predefined/actions/AppResultAdaptor.ejs.t
+++ b/src/templates/predefined/actions/AppResultAdaptor.ejs.t
@@ -1,8 +1,8 @@
 ---
 to: App/Infrastructure/Utils/AppResultAdaptor.ts
 ---
-import AppResult from "../../Application/Utils/AppResult";
-import HttpResp from "../../Application/Utils/HttpResp";
+import AppResult from "@application/Utils/AppResult";
+import HttpResp from "@application/Utils/HttpResp";
 
 class AppResultAdaptor {
   public appResult: AppResult;

--- a/src/templates/predefined/actions/baseDTO.ejs.t
+++ b/src/templates/predefined/actions/baseDTO.ejs.t
@@ -1,7 +1,7 @@
 ---
 to: App/Application/Utils/BaseDTO.ts
 ---
-import BaseDTOInterface from "./BaseDTOInterface";
+import BaseDTOInterface from "@application/Utils/BaseDTOInterface";
 
 class BaseDTO implements BaseDTOInterface {
   public allowedRoles = []

--- a/src/templates/predefined/actions/baseEntity.ejs.t
+++ b/src/templates/predefined/actions/baseEntity.ejs.t
@@ -2,7 +2,7 @@
 to: App/Domain/BaseEntity.ts
 ---
 import {v4 as uuidV4} from "uuid";
-import EntityInterface from "./EntityInterface";
+import EntityInterface from "@domain/EntityInterface";
 
 class BaseEntity implements EntityInterface {
   public createdAt: Date;

--- a/src/templates/predefined/actions/config.ejs.t
+++ b/src/templates/predefined/actions/config.ejs.t
@@ -1,9 +1,9 @@
 ---
 to: App/Infrastructure/Config/index.ts
 ---
-import database from './database';
-import server from './server';
-import application from './application';
+import database from '@infrastructure/Config/database';
+import server from '@infrastructure/Config/server';
+import application from '@infrastructure/Config/application';
 
 export default {
   database,

--- a/src/templates/predefined/actions/logger.ejs.t
+++ b/src/templates/predefined/actions/logger.ejs.t
@@ -2,7 +2,7 @@
 to: App/Infrastructure/Logger/logger.ts
 ---
 import pino from "pino";
-import {IAppLogger} from "../../Application/IAppLogger";
+import {IAppLogger} from "@application/IAppLogger";
 
 const pinoLogger = pino();
 

--- a/src/templates/predefined/actions/paginatedData.ejs.t
+++ b/src/templates/predefined/actions/paginatedData.ejs.t
@@ -1,7 +1,7 @@
 ---
 to: App/Domain/Utils/PaginatedData.ts
 ---
-import PaginationOptions from "./PaginationOptions";
+import PaginationOptions from "@domain/Utils/PaginationOptions";
 
 class PaginationData<T> {
   public paginationOptions: PaginationOptions;

--- a/src/templates/predefined/actions/www.ejs.t
+++ b/src/templates/predefined/actions/www.ejs.t
@@ -4,9 +4,9 @@ to: Bin/www.ts
 import * as dotenv from "dotenv";
 
 dotenv.config();
-import config from "../App/Infrastructure/Config";
-import logger from "../App/Infrastructure/Logger/logger";
-import httpServer from "../HTTP/Bootstrap/app";
+import config from "@infrastructure/Config";
+import logger from "@infrastructure/Logger/logger";
+import httpServer from "@http/Bootstrap/app";
 
 const {server, application} = config;
 

--- a/src/templates/scaffold/actions/Controller.ejs.t
+++ b/src/templates/scaffold/actions/Controller.ejs.t
@@ -2,14 +2,14 @@
 to: HTTP/Controllers/Api/V1/<%= name%>/<%= name%>.ts
 ---
 import {injectable,inject} from "tsyringe";
-import container from "../../../../../App/Infrastructure/IocContainer/container";
-import <%- name -%>Service from "../../../../../App/Application/<%- name -%>/<%- name -%>Service";
-import Create<%- name -%>DTO from "../../../../../App/Application/<%- name -%>/Create<%- name -%>DTO";
-import FetchAll<%- pluralizeName -%>DTO from "../../../../../App/Application/<%- name -%>/FetchAll<%- pluralizeName -%>DTO";
-import Update<%- name -%>DTO from "../../../../../App/Application/<%- name -%>/Update<%- name -%>DTO";
-import Fetch<%- name -%>ByIdDTO from "../../../../../App/Application/<%- name -%>/Fetch<%- name -%>ByIdDTO";
-import Remove<%- name -%>DTO from "../../../../../App/Application/<%- name -%>/Remove<%- name -%>DTO";
-import AppResultAdaptor from "../../../../../App/Infrastructure/Utils/AppResultAdaptor";
+import container from "@infrastructure/IocContainer/container";
+import <%- name -%>Service from "@application/<%- name -%>/<%- name -%>Service";
+import Create<%- name -%>DTO from "@application/<%- name -%>/Create<%- name -%>DTO";
+import FetchAll<%- pluralizeName -%>DTO from "@application/<%- name -%>/FetchAll<%- pluralizeName -%>DTO";
+import Update<%- name -%>DTO from "@application/<%- name -%>/Update<%- name -%>DTO";
+import Fetch<%- name -%>ByIdDTO from "@application/<%- name -%>/Fetch<%- name -%>ByIdDTO";
+import Remove<%- name -%>DTO from "@application/<%- name -%>/Remove<%- name -%>DTO";
+import AppResultAdaptor from "@infrastructure/Utils/AppResultAdaptor";
 
 container.resolve(<%- name -%>Service);
 

--- a/src/templates/scaffold/actions/CreateDTO.ejs.t
+++ b/src/templates/scaffold/actions/CreateDTO.ejs.t
@@ -1,8 +1,8 @@
 ---
 to: App/Application/<%= name%>/Create<%= name%>DTO.ts
 ---
-import BaseDTO from "../Utils/BaseDTO";
-import <%- name -%>Entity from "../../Domain/<%- name -%>/<%- name -%>Entity";
+import BaseDTO from "@application/Utils/BaseDTO";
+import <%- name -%>Entity from "@domain/<%- name -%>/<%- name -%>Entity";
 
 class Create<%- name -%>DTO extends BaseDTO {
   public <%- name.toLowerCase() -%>Id: string;

--- a/src/templates/scaffold/actions/Entity.ejs.t
+++ b/src/templates/scaffold/actions/Entity.ejs.t
@@ -4,7 +4,7 @@ to: App/Domain/<%- name%>/<%= name%>Entity.ts
 <% let constructorParams = ""-%>
 <% let methodParams = "" -%>
 
-import BaseEntity from "../BaseEntity";
+import BaseEntity from "@domain/BaseEntity";
 class <%- name%>Entity extends BaseEntity {
 <%for(let i=0;i<parameters.length;i++){-%>
  <% if(parameters[i].includes(':')) { -%>

--- a/src/templates/scaffold/actions/EntityInterface.ejs.t
+++ b/src/templates/scaffold/actions/EntityInterface.ejs.t
@@ -1,9 +1,9 @@
 ---
 to: App/Domain/<%- name%>/I<%= name%>Repository.ts
 ---
-import <%- name%>Entity from "./<%- name%>Entity";
-import PaginationData from "../../../Infrastructure/Utils/PaginationData";
-import PaginationOptions from "../../../Infrastructure/Utils/PaginationOptions";
+import <%- name%>Entity from "@domain/<%- name -%>/<%- name%>Entity";
+import PaginationData from "@domain/Utils/PaginatedData";
+import PaginationOptions from "@domain/Utils/PaginationOptions";
 
 export interface I<%- name%>Repository {
   add<%- name%>(<%- name.toLowerCase()%>: <%- name%>Entity): Promise<void>;

--- a/src/templates/scaffold/actions/FetchAllDTO.ejs.t
+++ b/src/templates/scaffold/actions/FetchAllDTO.ejs.t
@@ -1,8 +1,8 @@
 ---
 to: App/Application/<%= name%>/FetchAll<%= pluralizeName%>DTO.ts
 ---
-import BaseDTO from "../Utils/BaseDTO";
-import PaginationOptions from "../../Domain/Utils/PaginationOptions";
+import BaseDTO from "@application/Utils/BaseDTO";
+import PaginationOptions from "@domain/Utils/PaginationOptions";
 
 class FetchAll<%- pluralizeName -%>DTO extends BaseDTO {
   private readonly page: number = 1;

--- a/src/templates/scaffold/actions/FetchByIdDTO.ejs.t
+++ b/src/templates/scaffold/actions/FetchByIdDTO.ejs.t
@@ -1,7 +1,7 @@
 ---
 to: App/Application/<%= name%>/Fetch<%= name%>ByIdDTO.ts
 ---
-import BaseDTO from "../Utils/BaseDTO";
+import BaseDTO from "@application/Utils/BaseDTO";
 
 class Fetch<%- name -%>ByIdDTO extends BaseDTO {
   public <%- name.toLowerCase() -%>Id: string;

--- a/src/templates/scaffold/actions/RemoveDTO.ejs.t
+++ b/src/templates/scaffold/actions/RemoveDTO.ejs.t
@@ -1,7 +1,7 @@
 ---
 to: App/Application/<%= name%>/Remove<%= name%>DTO.ts
 ---
-import BaseDTO from "../Utils/BaseDTO";
+import BaseDTO from "@application/Utils/BaseDTO";
 
 class Remove<%- name -%>DTO extends BaseDTO {
   public <%- name.toLowerCase() -%>Id: string;

--- a/src/templates/scaffold/actions/Repository.ejs.t
+++ b/src/templates/scaffold/actions/Repository.ejs.t
@@ -3,9 +3,9 @@ to: App/Infrastructure/MySQLRepository/<%= name%>Repository.ts
 ---
 import { PrismaClient } from '@prisma/client'
 const prisma = new PrismaClient();
-import <%- name -%>Entity from "../../Domain/<%- name -%>/<%- name -%>Entity";
-import PaginatedData from "../../Domain/Utils/PaginatedData";
-import {I<%- name -%>Repository} from "../../Domain/<%- name -%>/I<%- name -%>Repository";
+import <%- name -%>Entity from "@domain/<%- name -%>/<%- name -%>Entity";
+import PaginatedData from "@domain/Utils/PaginatedData";
+import {I<%- name -%>Repository} from "@domain/<%- name -%>/I<%- name -%>Repository";
 import {injectable} from "tsyringe";
 
 const <%- name -%> = prisma.<%- name.toLowerCase() -%>;

--- a/src/templates/scaffold/actions/Route.ejs.t
+++ b/src/templates/scaffold/actions/Route.ejs.t
@@ -2,8 +2,8 @@
 to: HTTP/Routes/Api/V1/<%= name%>/<%= name%>.ts
 ---
 import * as express from "express";
-import <%- name -%>Controller from "../../../../Controllers/Api/V1/<%- name -%>/<%- name -%>";
-import container from "../../../../../App/Infrastructure/IocContainer/container";
+import <%- name -%>Controller from "@controller/Api/V1/<%- name -%>/<%- name -%>";
+import container from "@infrastructure/IocContainer/container";
 
 const <%- name.toLowerCase() -%>Controller = container.resolve(<%- name -%>Controller);
 const router = express.Router({mergeParams: true});

--- a/src/templates/scaffold/actions/Service.ejs.t
+++ b/src/templates/scaffold/actions/Service.ejs.t
@@ -2,15 +2,15 @@
 to: App/Application/<%= name%>/<%= name%>Service.ts
 ---
 import {inject, injectable} from "tsyringe";
-import {I<%- name -%>Repository} from "../../Domain/<%- name -%>/I<%- name -%>Repository";
-import AppResult from "../Utils/AppResult";
-import PaginatedData from "../../Domain/Utils/PaginatedData";
-import Create<%- name -%>DTO from "./Create<%- name -%>DTO";
-import FetchAll<%- pluralizeName -%>DTO from "./FetchAll<%- pluralizeName -%>DTO";
-import Update<%- name -%>DTO from "./Update<%- name -%>DTO";
-import Fetch<%- name -%>ByIdDTO from "./Fetch<%- name -%>ByIdDTO";
-import Remove<%- name -%>DTO from "./Remove<%- name -%>DTO";
-import <%- name -%>Entity from "../../Domain/<%- name -%>/<%- name -%>Entity";
+import {I<%- name -%>Repository} from "@domain/<%- name -%>/I<%- name -%>Repository";
+import AppResult from "@application/Utils/AppResult";
+import PaginatedData from "@domain/Utils/PaginatedData";
+import Create<%- name -%>DTO from "@application/<%- name -%>/Create<%- name -%>DTO";
+import FetchAll<%- pluralizeName -%>DTO from "@application/<%- name -%>/FetchAll<%- pluralizeName -%>DTO";
+import Update<%- name -%>DTO from "@application/<%- name -%>/Update<%- name -%>DTO";
+import Fetch<%- name -%>ByIdDTO from "@application/<%- name -%>/Fetch<%- name -%>ByIdDTO";
+import Remove<%- name -%>DTO from "@application/<%- name -%>/Remove<%- name -%>DTO";
+import <%- name -%>Entity from "@domain/<%- name -%>/<%- name -%>Entity";
 
 @injectable()
 class <%- name -%>Service {

--- a/src/templates/scaffold/actions/UpdateDTO.ejs.t
+++ b/src/templates/scaffold/actions/UpdateDTO.ejs.t
@@ -1,8 +1,8 @@
 ---
 to: App/Application/<%= name%>/Update<%= name%>DTO.ts
 ---
-import BaseDTO from "../Utils/BaseDTO";
-import <%- name -%>Entity from "../../Domain/<%- name -%>/<%- name -%>Entity";
+import BaseDTO from "@application/Utils/BaseDTO";
+import <%- name -%>Entity from "@domain/<%- name -%>/<%- name -%>Entity";
 
 class Update<%- name -%>DTO extends BaseDTO {
   public <%- name.toLowerCase() -%>: <%- name -%>Entity;

--- a/src/templates/scaffold/actions/importRoutesInjector.ejs.t
+++ b/src/templates/scaffold/actions/importRoutesInjector.ejs.t
@@ -4,4 +4,4 @@ inject: true
 after: component
 skip_if: <%- name %>
 ---
-<%- `import ${name} from "../Routes/Api/V1/${name}/${name}";` %>
+<%- `import ${name} from "@routes/Api/V1/${name}/${name}";` %>

--- a/src/templates/scaffold/actions/iocContainerRepositoryInjector.ejs.t
+++ b/src/templates/scaffold/actions/iocContainerRepositoryInjector.ejs.t
@@ -2,6 +2,6 @@
 to: App/Infrastructure/IocContainer/container.ts
 inject: true
 after: component
-skip_if: <%- `import ${name}Repository from "../MySQLRepository/${name}Repository";` %>
+skip_if: <%- `import ${name}Repository from "@infratructure/MySQLRepository/${name}Repository";` %>
 ---
-<%- `import ${name}Repository from "../MySQLRepository/${name}Repository";` %>
+<%- `import ${name}Repository from "@infrastructure/MySQLRepository/${name}Repository";` %>

--- a/src/templates/scaffold/actions/iocContainerRepositoryInterfaceInjector.ejs.t
+++ b/src/templates/scaffold/actions/iocContainerRepositoryInterfaceInjector.ejs.t
@@ -2,6 +2,6 @@
 to: App/Infrastructure/IocContainer/container.ts
 inject: true
 after: interface
-skip_if: <%- `import {I${name}Repository} from "../../Domain/${name}/I${name}Repository";` %>
+skip_if: <%- `import {I${name}Repository} from "@domain/${name}/I${name}Repository";` %>
 ---
-<%- `import {I${name}Repository} from "../../Domain/${name}/I${name}Repository";` %>
+<%- `import {I${name}Repository} from "@domain/${name}/I${name}Repository";` %>

--- a/src/templates/scaffold/actions/iocContainerServiceInjector.ejs.t
+++ b/src/templates/scaffold/actions/iocContainerServiceInjector.ejs.t
@@ -2,6 +2,6 @@
 to: App/Infrastructure/IocContainer/container.ts
 inject: true
 after: utilizer
-skip_if: <%- `import ${name}Service from "../../Application/${name}/${name}Service";` %>
+skip_if: <%- `import ${name}Service from "@application/${name}/${name}Service";` %>
 ---
-<%- `import ${name}Service from "../../Application/${name}/${name}Service";` %>
+<%- `import ${name}Service from "@application/${name}/${name}Service";` %>


### PR DESCRIPTION
Typescript aliases allow you to specify a word/alias for an absolute path in the application from which you can resolve paths from absolutely. This means that you can have an alias called @app for the absolute path “src/app” and if you wanted to import a module from “src/app/config/config.ts” you would import it like “@app/config/config.ts” from everywhere in your application! Now every other file that imports config.ts will have the exact same path, so if you want to move config.ts at some point, you would be able to just do a find and replace for the path.